### PR TITLE
ci: org reusable Go release pipeline + Dependabot templates (internal-docs#66)

### DIFF
--- a/.github/workflows/release-go-service.yml
+++ b/.github/workflows/release-go-service.yml
@@ -1,0 +1,303 @@
+name: Reusable Release (Go service)
+
+# Org-wide reusable release pipeline for Go services.
+#
+# One place to change how every service releases. It gates a release on the
+# test suite, `go vet`, and a govulncheck scan of reachable code; cross-compiles
+# each requested binary for each GOOS/GOARCH; and publishes a SINGLE GitHub
+# Release with a merged SHA256SUMS covering every asset. The single-publish
+# design fixes the concurrent action-gh-release clobber hazard in the old
+# per-arch-matrix variant, where each matrix leg raced to create the same
+# release (422 / partial-asset releases).
+#
+# See internal-docs/standards/infrastructure/ci-cd-practices.md.
+#
+# Minimal caller (single binary, default linux/arm64 + linux/amd64):
+#
+#   name: Release
+#   on:
+#     push:
+#       tags: ['v*']
+#   permissions:
+#     contents: write          # required: the reusable workflow publishes a Release
+#   jobs:
+#     release:
+#       uses: underveil-stacks/.github/.github/workflows/release-go-service.yml@main
+#       with:
+#         binaries: '[{"name":"pbj-api","main":"./cmd/server"}]'
+#
+# Multi-binary caller (e.g. wisp):
+#
+#       with:
+#         binaries: >-
+#           [{"name":"wisp-server","main":"./cmd/server"},
+#            {"name":"wisp-migrate","main":"./cmd/migrate"},
+#            {"name":"wisp","main":"./cmd/wisp"}]
+#
+# GoReleaser caller (repo owns a .goreleaser.yaml; life-api / music-enrich):
+#
+#       with:
+#         goreleaser: true
+#         binaries: '[]'        # ignored in goreleaser mode
+
+on:
+  workflow_call:
+    inputs:
+      binaries:
+        description: >-
+          JSON array of {"name","main"} objects. `name` is the binary base name
+          (the asset is published as <name>-<goos>-<goarch>); `main` is the main
+          package path (e.g. ./cmd/server). Ignored when goreleaser: true.
+        type: string
+        required: true
+      targets:
+        description: JSON array of "goos/goarch" strings to cross-compile.
+        type: string
+        default: '["linux/arm64","linux/amd64"]'
+      go-version:
+        description: Explicit Go version. Empty (default) uses go-version-file.
+        type: string
+        default: ''
+      go-version-file:
+        description: File to read the Go version from when go-version is empty.
+        type: string
+        default: go.mod
+      cgo-enabled:
+        description: CGO_ENABLED value for the build ('0' or '1').
+        type: string
+        default: '0'
+      trimpath:
+        description: Pass -trimpath to go build.
+        type: boolean
+        default: true
+      ldflags-extra:
+        description: Extra flags appended to -ldflags (after the version stamps).
+        type: string
+        default: ''
+      test-args:
+        description: Package selector for `go test` and `go vet`.
+        type: string
+        default: ./...
+      run-tests:
+        description: Run `go test` before building. Leave on unless a repo has a genuine reason.
+        type: boolean
+        default: true
+      run-vet:
+        description: Run `go vet` before building.
+        type: boolean
+        default: true
+      govulncheck:
+        description: Run govulncheck against reachable code and fail on findings.
+        type: boolean
+        default: true
+      govulncheck-version:
+        description: Version of the govulncheck tool to install (a security scanner; latest tracks the newest vuln DB tooling).
+        type: string
+        default: latest
+      extra-files:
+        description: Newline-separated globs of additional files to attach to the Release.
+        type: string
+        default: ''
+      goreleaser:
+        description: Use GoReleaser (repo-owned .goreleaser.yaml) instead of the build+release matrix.
+        type: boolean
+        default: false
+      prerelease-when:
+        description: Mark the Release as a prerelease when the tag contains one of these (comma-separated) substrings.
+        type: string
+        default: '-rc,-beta,-alpha'
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Gate: no untested or vulnerable code reaches a Release.
+  # ---------------------------------------------------------------------------
+  test:
+    name: Test & scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: go vet
+        if: ${{ inputs.run-vet }}
+        run: go vet ${{ inputs.test-args }}
+
+      - name: go test
+        if: ${{ inputs.run-tests }}
+        run: go test ${{ inputs.test-args }}
+
+      - name: govulncheck
+        if: ${{ inputs.govulncheck }}
+        # govulncheck exits non-zero only when a vulnerability is reachable from
+        # this module's code (call-graph analysis), so this fails on findings
+        # that actually affect the build, not on every advisory in the dep tree.
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.govulncheck-version }}
+          govulncheck ${{ inputs.test-args }}
+
+  # ---------------------------------------------------------------------------
+  # Cross-compile matrix (skipped in GoReleaser mode).
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build ${{ matrix.target }}
+    if: ${{ !inputs.goreleaser }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(inputs.targets) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Resolve target
+        id: tgt
+        run: |
+          t='${{ matrix.target }}'
+          {
+            echo "goos=${t%%/*}"
+            echo "goarch=${t##*/}"
+            echo "slug=${t//\//-}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Cross-compile
+        env:
+          GOOS: ${{ steps.tgt.outputs.goos }}
+          GOARCH: ${{ steps.tgt.outputs.goarch }}
+          CGO_ENABLED: ${{ inputs.cgo-enabled }}
+          BINARIES: ${{ inputs.binaries }}
+          VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          LDFLAGS_EXTRA: ${{ inputs.ldflags-extra }}
+        run: |
+          set -euo pipefail
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # main.version / main.gitCommit / main.buildTime are the stamps every
+          # service reads for /about and --version. -X on a symbol a given
+          # binary doesn't define is silently ignored by the Go linker.
+          LDFLAGS="-w -s -X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} ${LDFLAGS_EXTRA}"
+          TRIMPATH=""
+          if [ "${{ inputs.trimpath }}" = "true" ]; then TRIMPATH="-trimpath"; fi
+          mkdir -p dist
+          mapfile -t rows < <(printf '%s' "$BINARIES" | jq -c '.[]')
+          if [ "${#rows[@]}" -eq 0 ]; then
+            echo "::error::inputs.binaries is empty; provide at least one {name,main} object"
+            exit 1
+          fi
+          for row in "${rows[@]}"; do
+            name=$(printf '%s' "$row" | jq -r '.name')
+            main=$(printf '%s' "$row" | jq -r '.main')
+            out="dist/${name}-${GOOS}-${GOARCH}"
+            echo "Building $out from $main (GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED)"
+            go build ${TRIMPATH} -ldflags="$LDFLAGS" -o "$out" "$main"
+          done
+          ls -l dist
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist-${{ steps.tgt.outputs.slug }}
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Publish exactly one Release from a single job after all legs complete.
+  # ---------------------------------------------------------------------------
+  release:
+    name: Publish release
+    if: ${{ !inputs.goreleaser }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: |
+          set -euo pipefail
+          cd dist
+          # Exclude any pre-existing SHA256SUMS so the digest file never hashes
+          # itself; one merged file covers every asset (ci-cd-practices.md).
+          mapfile -t files < <(find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' | sort)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no binaries were downloaded from the build matrix"
+            exit 1
+          fi
+          sha256sum "${files[@]}" > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Determine prerelease
+        id: pre
+        env:
+          TAG: ${{ github.ref_name }}
+          MARKERS: ${{ inputs.prerelease-when }}
+        run: |
+          set -euo pipefail
+          pre=false
+          IFS=',' read -ra markers <<< "$MARKERS"
+          for m in "${markers[@]}"; do
+            [ -n "$m" ] || continue
+            case "$TAG" in *"$m"*) pre=true ;; esac
+          done
+          echo "prerelease=$pre" >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        with:
+          files: |
+            dist/*
+            ${{ inputs.extra-files }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ steps.pre.outputs.prerelease }}
+
+  # ---------------------------------------------------------------------------
+  # GoReleaser mode: repo owns .goreleaser.yaml (matrix + checksums live there).
+  # ---------------------------------------------------------------------------
+  goreleaser:
+    name: GoReleaser
+    if: ${{ inputs.goreleaser }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,40 @@
+# Org templates
+
+Copy-paste starting points for files that GitHub cannot inherit org-wide and
+that therefore must be committed into each repo.
+
+## `dependabot.yml` / `dependabot-spa.yml`
+
+Dependabot configuration is per-repo only — there is no org-level inheritance.
+Copy the right template to `.github/dependabot.yml` in each service repo:
+
+- **`dependabot.yml`** — Go service repos (gomod + github-actions, weekly).
+- **`dependabot-spa.yml`** — repos that also ship an SPA / Node front-end
+  (adds the npm ecosystem). `manuals-webui` is the current example.
+
+Org-wide Dependabot **alerts** and **security updates** are a separate,
+org-level setting (Settings → Code security) that only an org owner can enable;
+these files control the *version-update* PRs, not the alert feed.
+
+## Release pipeline
+
+Service repos do not need a template file for releases — they call the org
+reusable workflow directly:
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: underveil-stacks/.github/.github/workflows/release-go-service.yml@main
+    with:
+      binaries: '[{"name":"my-api","main":"./cmd/server"}]'
+```
+
+See [`release-go-service.yml`](../.github/workflows/release-go-service.yml) for
+all inputs (targets, multi-binary, CGO, GoReleaser mode, extra assets).

--- a/templates/dependabot-spa.yml
+++ b/templates/dependabot-spa.yml
@@ -1,0 +1,44 @@
+# Dependabot config for a repo that ships an SPA / Node front-end
+# (e.g. manuals-webui). Copy to `.github/dependabot.yml`.
+#
+# Same as templates/dependabot.yml plus the npm ecosystem. Set `directory` to
+# wherever the package.json / lockfile lives (root here; use e.g. "/web" if the
+# SPA is in a subdir).
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "deps(npm)"
+
+  # Include gomod as well if the repo also has a Go module; drop it for a
+  # pure-frontend repo.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "deps(go)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(actions)"

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,0 +1,35 @@
+# Canonical Dependabot config for a Go service repo.
+#
+# Dependabot config is NOT inheritable org-wide — every repo needs its own copy.
+# Copy this file to `.github/dependabot.yml` in the target repo.
+#
+# For a repo that also ships an SPA (a `package.json` / lockfile), add the npm
+# ecosystem block from templates/dependabot-spa.yml.
+
+version: 2
+updates:
+  # Go module dependencies — the large, unscanned surface.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Batch patch/minor bumps into one PR to cut review churn; majors stay
+      # individual so breaking changes are reviewed on their own.
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "deps(go)"
+
+  # GitHub Actions — keeps SHA pins current. Dependabot understands SHA-pinned
+  # actions and bumps both the SHA and the trailing version comment.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(actions)"


### PR DESCRIPTION
## What & why

One org-maintained release pipeline for Go services, so a standard change lands in one PR instead of ten and **untested / unscanned releases become structurally impossible**. Closes the CI/CD finding in underveil-stacks/internal-docs#66.

Today release.yml has forked into four copy-pasted variants: 7 of 10 service repos publish tags with no `go test`, **zero** repos run any vulnerability scan (357 Go module deps + node lockfiles serving internet-facing endpoints), and the rivulet/wisp variant has every matrix leg calling `action-gh-release` for the same tag concurrently — a known clobber/422 hazard that can leave a Release with only one arch's assets.

## What's in this PR (org `.github` repo only)

**`.github/workflows/release-go-service.yml`** — a `workflow_call` reusable pipeline (house-style modeled on the existing `auto-add-to-dashboard.yml`):

- **`test` job (the gate):** `go vet`, `go test`, and `govulncheck` on every release. `needs: test` guards the build, so nothing untested or vulnerable reaches a Release.
- **`build` job:** matrix over a caller-supplied `targets` list (default `linux/arm64,linux/amd64`); builds each binary in the caller's `binaries` JSON array (`{name, main}`), stamping `main.version` / `main.gitCommit` / `main.buildTime` via `-ldflags`; uploads per-leg artifacts.
- **`release` job (single publish):** downloads all legs, generates **one merged `SHA256SUMS`**, and calls `action-gh-release` **once**. This is the clobber fix — the release is created exactly once, after all arches succeed, instead of racing per matrix leg.
- **`goreleaser` job (optional):** `goreleaser: true` runs the repo's `.goreleaser.yaml` behind the same test+vuln gate, so life-api / music-enrich get the gate without abandoning GoReleaser.

All actions SHA-pinned per `ci-cd-practices.md`. A typical caller is ~10 lines.

**`templates/`** — `dependabot.yml` (gomod + github-actions, weekly, grouped minor/patch) and `dependabot-spa.yml` (adds npm) plus a README. These are copy-paste templates, not inherited config: **Dependabot config cannot be inherited org-wide**, so each repo needs its own `.github/dependabot.yml`.

### Design decisions

- **Clobber fix = single-publish topology.** Build matrix uploads artifacts; a lone downstream `release` job (`needs: build`) creates the Release once. This is the pbj/manuals two-job shape generalized, replacing the rivulet/wisp per-leg `action-gh-release` + separate `--clobber` checksum upload.
- **govulncheck policy:** installed and run as `govulncheck ./...` (install-and-run, tool version an input defaulting to `latest` so it always uses the newest scanner/DB). govulncheck exits non-zero **only when a vuln is reachable from this module's code** (call-graph analysis) — so it fails on findings that affect the build, not on every advisory in the dependency tree. Toggle via `govulncheck: false` if ever needed.
- **Inputs & defaults** (sensible enough that most callers set only `binaries`): `targets` (default arm64+amd64), `go-version` / `go-version-file` (default reads `go.mod`), `cgo-enabled` (`0`), `trimpath` (`true`), `ldflags-extra`, `test-args` (`./...`), `run-tests` / `run-vet` / `govulncheck` toggles, `extra-files` (extra release assets), `prerelease-when` (default marks `-rc/-beta/-alpha` tags prerelease), `goreleaser`.
- **Binary naming** unified to `<name>-<goos>-<goarch>`, matching what every current deploy consumer already downloads.
- Validated: all YAML parses; `actionlint` (1.7.12) reports the workflow **clean** (the one remaining warning is pre-existing in `cicd-dashboard.yml`, untouched here).

## Variant survey (what the pipeline had to absorb)

| Repo | Shape today | Tests? | Binaries (`main`) |
|---|---|---|---|
| pbj | build-matrix → single release | no | `pbj-api` (`./cmd/server`) |
| manuals-api | build-matrix → single release | no | `manualsd` (`./cmd/manualsd`) |
| engram | single job, seq arches | no | `engram` (`./cmd/engram`) |
| kitchen-notes-api | single job, seq arches | no | `kitchen-notes-api` (`./cmd/kitchen-notes-api`) |
| atelier-api | single job, arch loop, `-trimpath` | no | `atelier-api` (`./cmd/server`), `atelier-migrate`, `atelier-admin` |
| rivulet | **per-leg matrix (clobber)** + checksums job | no | `server` (`./cmd/server`), `rivulet` (`./cmd/rivulet`) |
| wisp | **per-leg matrix (clobber)** + checksums job | no | `wisp-server` (`./cmd/server`), `wisp-migrate`, `wisp` |
| bsky-tool | single job, test then build | **yes** | `bsky-tool` (`./cmd/bsky-tool`) |
| life-api | **GoReleaser**, test then release | **yes** | `.goreleaser.yaml` |
| music-enrich | **GoReleaser**, test then release | **yes** | `.goreleaser.yaml` |

Common denominators the reusable workflow standardizes: `CGO_ENABLED=0`, `-w -s` + version/commit/buildTime ldflags, `linux` arm64+amd64, `SHA256SUMS` over all assets, `generate_release_notes: true`.

## Rollout checklist (follow-up per-repo PRs — NOT in this PR)

Each service repo: replace `.github/workflows/release.yml` with a caller, add `.github/dependabot.yml`. Pin the `uses:` to a `.github` release tag/SHA once this merges (the release path is supply-chain-adjacent; `@main` works but a pinned tag is preferred).

**Adopt first — live Dependabot advisories:**
- **manuals-webui** (SPA, npm — **1 high + 2 moderate**): add `dependabot-spa.yml` only; it's a static-site build, not a consumer of the release workflow.
- **rivulet** (**2 moderate**): also the clobber-hazard variant — double reason to go early.

**Caller `with:` per repo:**
- pbj — `binaries: '[{"name":"pbj-api","main":"./cmd/server"}]'`
- manuals-api — `binaries: '[{"name":"manualsd","main":"./cmd/manualsd"}]'`
- engram — `binaries: '[{"name":"engram","main":"./cmd/engram"}]'`
- kitchen-notes-api — `binaries: '[{"name":"kitchen-notes-api","main":"./cmd/kitchen-notes-api"}]'`
- rivulet — `binaries: '[{"name":"server","main":"./cmd/server"},{"name":"rivulet","main":"./cmd/rivulet"}]'`
- wisp — `binaries: '[{"name":"wisp-server","main":"./cmd/server"},{"name":"wisp-migrate","main":"./cmd/migrate"},{"name":"wisp","main":"./cmd/wisp"}]'`
- atelier-api — `binaries: '[{"name":"atelier-api","main":"./cmd/server"},{"name":"atelier-migrate","main":"./cmd/atelier-migrate"},{"name":"atelier-admin","main":"./cmd/atelier-admin"}]'`
- bsky-tool — `binaries: '[{"name":"bsky-tool","main":"./cmd/bsky-tool"}]'`
- life-api — `goreleaser: true` (+ `binaries: '[]'`)
- music-enrich — `goreleaser: true` (+ `binaries: '[]'`)

Each caller: `on: push: tags: ['v*']`, `permissions: contents: write`, and omit `go-version` (defaults to `go.mod`) unless a specific toolchain is required. Dependabot: engram + music-enrich already have configs (align them to the template and **merge their stale open PRs**); the other eight need one added.

**Operator-only, org-level (cannot be set from a repo PR):**
- Enable **Dependabot alerts** and **Dependabot security updates** org-wide (Org Settings → Code security), plus the Dependency graph prerequisite. The templates control version-update PRs; the alert feed is a separate org toggle.
- **Branch protection is still needed.** This pipeline makes untested *releases* impossible, but pbj/rivulet/engram only run CI on `pull_request`, so direct pushes to `main` remain untested. Add required PR status checks + branch protection on `main` to close that gap (a separate `test.yml` on `pull_request`, out of scope here).

Refs underveil-stacks/internal-docs#66. Do not merge until operator review.
